### PR TITLE
Add Custom URL Scheme for Auth callbacks

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="io.ionic.starter" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
-    <name>MyApp</name>
-    <description>An awesome Ionic/Cordova app.</description>
-    <author email="hi@ionicframework" href="http://ionicframework.com/">Ionic Framework Team</author>
+<widget id="com.clueride" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>Front-end Common</name>
+    <description>Support for Clue Ride's Ionic mobile Apps</description>
+    <author href="https://github.com/ClueRide/">Clue Ride</author>
     <content src="index.html" />
     <access origin="*" />
     <allow-intent href="http://*/*" />
@@ -12,15 +12,11 @@
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
     <preference name="ScrollEnabled" value="false" />
+    <preference name="AndroidLaunchMode" value="singleTask" />
     <preference name="android-minSdkVersion" value="16" />
     <preference name="BackupWebStorage" value="none" />
     <preference name="SplashMaintainAspectRatio" value="true" />
     <preference name="FadeSplashScreenDuration" value="300" />
-
-    <!--
-      Change these to configure how the splashscreen displays and fades in/out.
-      More info here: https://github.com/apache/cordova-plugin-splashscreen
-    -->
     <preference name="SplashShowOnlyFirstTime" value="false" />
     <preference name="SplashScreen" value="screen" />
     <preference name="SplashScreenDelay" value="3000" />
@@ -86,4 +82,11 @@
     <plugin name="cordova-plugin-device" spec="1.1.4" />
     <plugin name="cordova-plugin-splashscreen" spec="~4.0.1" />
     <plugin name="cordova-plugin-ionic-webview" spec="^1.1.11" />
+    <plugin name="cordova-plugin-safariviewcontroller" spec="^1.5.2" />
+    <plugin name="cordova-plugin-customurlscheme" spec="^4.3.0">
+        <variable name="URL_SCHEME" value="com.clueride" />
+        <variable name="ANDROID_SCHEME" value="com.clueride" />
+        <variable name="ANDROID_HOST" value="clueride.auth0.com" />
+        <variable name="ANDROID_PATHPREFIX" value="/cordova/com.clueride/callback" />
+    </plugin>
 </widget>

--- a/ionic.config.json
+++ b/ionic.config.json
@@ -2,5 +2,7 @@
   "name": "front-end-common",
   "app_id": "",
   "type": "ionic-angular",
-  "integrations": {}
+  "integrations": {
+    "cordova": {}
+  }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,75 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/0.13/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine', '@angular/cli'],
+
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-junit-reporter'),
+      require("karma-coverage-istanbul-reporter"),
+      require('@angular/cli/plugins/karma')
+    ],
+
+    client: {
+      clearContext: false
+    },
+
+    // list of files / patterns to load in the browser
+    files: [
+      { pattern: './src/test.ts', watched: false }
+    ],
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      './src/test.ts': ['@angular/cli']
+    },
+    mime: {
+      'text/x-typescript': ['ts','tsx']
+    },
+    coverageIstanbulReporter: {
+      reports: [ 'html', 'lcovonly'],
+      fixWebpackSourcePaths: true
+    },
+
+    angularCli: {
+      config: './angular-cli.json',
+      environment: 'dev'
+    },
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: config.angularCli && config.angularCli.codeCoverage
+      ? ['progress', 'coverage-istanbul']
+      : ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity
+  })
+};

--- a/package.json
+++ b/package.json
@@ -1,43 +1,56 @@
 {
-  "name": "front-end-common",
-  "version": "0.0.1",
-  "author": "Clue Ride",
-  "homepage": "https://clueride.com/",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "private": true,
-  "scripts": {
-    "clean": "ionic-app-scripts clean",
-    "build": "ionic-app-scripts build",
-    "build-ngc": "ngc",
-    "tsc-npm": "tsc -p tsconfig.npm.json",
-    "watch": "rm -rf aot dist && npm run ngc",
-    "lint": "ionic-app-scripts lint",
-    "ionic:build": "ionic-app-scripts build",
-    "ionic:serve": "ionic-app-scripts serve"
-  },
-  "dependencies": {
-    "@angular/common": "5.0.0",
-    "@angular/compiler": "5.0.0",
-    "@angular/compiler-cli": "5.0.0",
-    "@angular/core": "5.0.0",
-    "@angular/forms": "5.0.0",
-    "@angular/http": "5.0.0",
-    "@angular/platform-browser": "5.0.0",
-    "@angular/platform-browser-dynamic": "5.0.0",
-    "@ionic-native/core": "4.3.2",
-    "@ionic-native/splash-screen": "4.3.2",
-    "@ionic-native/status-bar": "4.3.2",
-    "@ionic/storage": "2.1.3",
-    "ionic-angular": "3.9.2",
-    "ionicons": "3.0.0",
-    "rxjs": "5.5.2",
-    "sw-toolbox": "3.6.0",
-    "zone.js": "0.8.18"
-  },
-  "devDependencies": {
-    "@ionic/app-scripts": "3.1.0",
-    "typescript": "2.4.2"
-  },
-  "description": "An Ionic project"
+    "name": "front-end-common",
+    "version": "0.0.1",
+    "author": "Clue Ride",
+    "homepage": "https://github.com/ClueRide",
+    "description": "Shared components and services supporting Clue Ride Ionic Mobile Apps",
+    "private": true,
+    "scripts": {
+        "clean": "ionic-app-scripts clean",
+        "build": "ionic-app-scripts build",
+        "lint": "ionic-app-scripts lint",
+        "ionic:build": "ionic-app-scripts build",
+        "ionic:serve": "ionic-app-scripts serve",
+        "test": "ng test"
+    },
+    "dependencies": {
+        "@angular/common": "5.0.0",
+        "@angular/compiler": "5.0.0",
+        "@angular/compiler-cli": "5.0.0",
+        "@angular/core": "5.0.0",
+        "@angular/forms": "5.0.0",
+        "@angular/http": "5.0.0",
+        "@angular/platform-browser": "5.0.0",
+        "@angular/platform-browser-dynamic": "5.0.0",
+        "@auth0/cordova": "^0.3.0",
+        "@ionic-native/core": "4.3.2",
+        "@ionic-native/splash-screen": "4.3.2",
+        "@ionic-native/status-bar": "4.3.2",
+        "@ionic/storage": "2.1.3",
+        "auth0-js": "^9.0.2",
+        "cordova-plugin-customurlscheme": "^4.3.0",
+        "cordova-plugin-safariviewcontroller": "^1.5.2",
+        "ionic-angular": "3.9.2",
+        "ionicons": "3.0.0",
+        "rxjs": "5.5.2",
+        "sw-toolbox": "3.6.0",
+        "zone.js": "0.8.18"
+    },
+    "devDependencies": {
+        "@ionic/app-scripts": "3.1.0",
+        "jasmine": "^2.8.0",
+        "karma": "^2.0.0",
+        "typescript": "2.4.2"
+    },
+    "cordova": {
+        "plugins": {
+            "cordova-plugin-safariviewcontroller": {},
+            "cordova-plugin-customurlscheme": {
+                "URL_SCHEME": "com.clueride",
+                "ANDROID_SCHEME": "com.clueride",
+                "ANDROID_HOST": "clueride.auth0.com",
+                "ANDROID_PATHPREFIX": "/cordova/com.clueride/callback"
+            }
+        }
+    }
 }

--- a/src/components/components.module.ts
+++ b/src/components/components.module.ts
@@ -1,19 +1,21 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
-import {TokenService} from "../providers/token-service/token-service";
 import {IonicStorageModule} from "@ionic/storage";
 import {RegistrationPageModule} from "../pages/registration/registration.module";
+import {AuthService} from "../providers/auth/auth.service";
 
 @NgModule({
   imports: [
     IonicStorageModule.forRoot({driverOrder:  ['localstorage', 'sqlite', 'indexeddb', 'websql']}),
-    RegistrationPageModule
+    RegistrationPageModule,
   ],
 })
 export class ComponentsModule {
   static forRoot(): ModuleWithProviders {
     return {
       ngModule: ComponentsModule,
-      providers: [ TokenService ]
+      providers: [
+        AuthService
+      ]
     }
   }
 }

--- a/src/pages/registration/registration.html
+++ b/src/pages/registration/registration.html
@@ -14,6 +14,20 @@
 
 
 <ion-content padding>
-  Placeholder
-
+  <div id="welcome">
+    Welcome to Clue Ride Player.
+  </div>
+  <div *ngIf="!auth.isAuthenticated()">
+    <div id="login">
+      This device is not yet registered on the Clue Ride network. Please <a (click)="auth.login()">Log In</a> to continue.
+    </div>
+  </div>
+  <div *ngIf="auth.isAuthenticated()">
+    <div>
+      You're good to go.
+    </div>
+    <div id="logout">
+      <a (click)="auth.logout()">Log Out</a>
+    </div>
+  </div>
 </ion-content>

--- a/src/pages/registration/registration.ts
+++ b/src/pages/registration/registration.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
-import { IonicPage, NavController, NavParams } from 'ionic-angular';
+import { IonicPage } from 'ionic-angular';
+import {AuthService} from "../../providers/auth/auth.service";
 
 /**
  * Generated class for the RegistrationPage page.
@@ -15,7 +16,9 @@ import { IonicPage, NavController, NavParams } from 'ionic-angular';
 })
 export class RegistrationPage {
 
-  constructor(public navCtrl: NavController, public navParams: NavParams) {
+  constructor(
+    public auth: AuthService,
+  ) {
   }
 
   ionViewDidLoad() {

--- a/src/providers/auth/auth.service.ts
+++ b/src/providers/auth/auth.service.ts
@@ -1,0 +1,98 @@
+import {Injectable, NgZone} from "@angular/core";
+
+import Auth0Cordova from "@auth0/cordova";
+import Auth0 from "auth0-js";
+import {AUTH_CONFIG} from "./auth0-variables";
+
+const auth0Config = {
+  // needed for auth0
+  clientID: AUTH_CONFIG.clientID,
+
+  // needed for auth0cordova
+  clientId: AUTH_CONFIG.clientID,
+  domain: AUTH_CONFIG.domain,
+  // callbackURL: location.href,
+  packageIdentifier: 'com.clueride'
+};
+
+@Injectable()
+export class AuthService {
+  auth0 = new Auth0.WebAuth(auth0Config);
+  accessToken: string;
+  idToken: string;
+  user: any;
+
+  constructor(public zone: NgZone) {
+    this.user = this.getStorageVariable('profile');
+    this.idToken = this.getStorageVariable('id_token');
+  }
+
+  private getStorageVariable(name) {
+    return JSON.parse(window.localStorage.getItem(name));
+  }
+
+  private setStorageVariable(name, data) {
+    window.localStorage.setItem(name, JSON.stringify(data));
+  }
+
+  private setIdToken(token) {
+    this.idToken = token;
+    this.setStorageVariable('id_token', token);
+  }
+
+  private setAccessToken(token) {
+    this.accessToken = token;
+    this.setStorageVariable('access_token', token);
+  }
+
+  public isAuthenticated() {
+    const expiresAt = JSON.parse(localStorage.getItem('expires_at'));
+    return Date.now() < expiresAt;
+  }
+
+  public login() {
+    const client = new Auth0Cordova(auth0Config);
+
+    const options = {
+      scope: 'openid profile offline_access'
+    };
+
+    client.authorize(options, (err, authResult) => {
+      if(err) {
+        throw err;
+      }
+
+      console.log("Auth success with result: " + authResult);
+
+      this.setIdToken(authResult.idToken);
+      this.setAccessToken(authResult.accessToken);
+
+      const expiresAt = JSON.stringify((authResult.expiresIn * 1000) + new Date().getTime());
+      this.setStorageVariable('expires_at', expiresAt);
+
+      this.auth0.client.userInfo(this.accessToken, (err, profile) => {
+        if(err) {
+          throw err;
+        }
+
+        profile.user_metadata = profile.user_metadata || {};
+        this.setStorageVariable('profile', profile);
+        this.zone.run(() => {
+          this.user = profile;
+        });
+      });
+    });
+  }
+
+  public logout() {
+    window.localStorage.removeItem('profile');
+    window.localStorage.removeItem('access_token');
+    window.localStorage.removeItem('id_token');
+    window.localStorage.removeItem('expires_at');
+
+    this.idToken = null;
+    this.accessToken = null;
+    this.user = null;
+  }
+
+}

--- a/src/providers/auth/auth0-variables.ts
+++ b/src/providers/auth/auth0-variables.ts
@@ -1,0 +1,11 @@
+interface AuthConfig {
+  clientID: string;
+  domain: string;
+  callbackURL: string;
+}
+
+export const AUTH_CONFIG: AuthConfig = {
+  clientID: 'd3bsa3YiIVKeUQZI98n0258d7fXW64j7',
+  domain: 'clueride.auth0.com',
+  callbackURL: 'com.clueride://clueride.auth0.com/cordova/com.clueride/callback'
+};

--- a/src/providers/token-service/token-service.ts
+++ b/src/providers/token-service/token-service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Storage } from "@ionic/storage";
 
+/**
+ * @deprecated use AuthService instead.
+ */
 @Injectable()
 export class TokenService {
   TOKEN_KEY: string = "token.key";


### PR DESCRIPTION
* Adds Auth service supporting Ionic 3.
* Deprecates (but doesn't yet remove) TokenService.
* Registration page is built up a little more with the inclusion of
a logout.

The file config.xml contains common config, but this isn't used here.
The app itself will need to step in with some of the configuration
values since that's where the plugin does its work -- within app build.