### PR TITLE
explore-JWT-helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-### :point_right: This starter repo has moved to the [ionic-team/starters](https://github.com/ionic-team/starters/tree/master/ionic-angular/official/blank) repo! :point_left:
+# Responsibilities
+Landing spot for code that is shared across the front end apps.
+
+Currently holds:
+* Registration pages
+* Authentication service (Auth0-based)
+* Token Service
+
+Future:
+* API services for talking to the back-end.

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@
  * Created by jett on 1/1/18.
  */
 
+export { AuthService } from "./src/providers/auth/auth.service";
 export { ComponentsModule } from "./src/components/components.module";
 export { RegistrationPage } from "./src/pages/registration/registration";
-export { TokenService } from "./src/providers/token-service/token-service";
+export { TokenService } from "./src/providers/token/token.service";

--- a/package.json
+++ b/package.json
@@ -1,56 +1,57 @@
 {
-    "name": "front-end-common",
-    "version": "0.0.1",
-    "author": "Clue Ride",
-    "homepage": "https://github.com/ClueRide",
-    "description": "Shared components and services supporting Clue Ride Ionic Mobile Apps",
-    "private": true,
-    "scripts": {
-        "clean": "ionic-app-scripts clean",
-        "build": "ionic-app-scripts build",
-        "lint": "ionic-app-scripts lint",
-        "ionic:build": "ionic-app-scripts build",
-        "ionic:serve": "ionic-app-scripts serve",
-        "test": "ng test"
-    },
-    "dependencies": {
-        "@angular/common": "5.0.0",
-        "@angular/compiler": "5.0.0",
-        "@angular/compiler-cli": "5.0.0",
-        "@angular/core": "5.0.0",
-        "@angular/forms": "5.0.0",
-        "@angular/http": "5.0.0",
-        "@angular/platform-browser": "5.0.0",
-        "@angular/platform-browser-dynamic": "5.0.0",
-        "@auth0/cordova": "^0.3.0",
-        "@ionic-native/core": "4.3.2",
-        "@ionic-native/splash-screen": "4.3.2",
-        "@ionic-native/status-bar": "4.3.2",
-        "@ionic/storage": "2.1.3",
-        "auth0-js": "^9.0.2",
-        "cordova-plugin-customurlscheme": "^4.3.0",
-        "cordova-plugin-safariviewcontroller": "^1.5.2",
-        "ionic-angular": "3.9.2",
-        "ionicons": "3.0.0",
-        "rxjs": "5.5.2",
-        "sw-toolbox": "3.6.0",
-        "zone.js": "0.8.18"
-    },
-    "devDependencies": {
-        "@ionic/app-scripts": "3.1.0",
-        "jasmine": "^2.8.0",
-        "karma": "^2.0.0",
-        "typescript": "2.4.2"
-    },
-    "cordova": {
-        "plugins": {
-            "cordova-plugin-safariviewcontroller": {},
-            "cordova-plugin-customurlscheme": {
-                "URL_SCHEME": "com.clueride",
-                "ANDROID_SCHEME": "com.clueride",
-                "ANDROID_HOST": "clueride.auth0.com",
-                "ANDROID_PATHPREFIX": "/cordova/com.clueride/callback"
-            }
-        }
+  "name": "front-end-common",
+  "version": "0.0.1",
+  "author": "Clue Ride",
+  "homepage": "https://github.com/ClueRide",
+  "description": "Shared components and services supporting Clue Ride Ionic Mobile Apps",
+  "private": true,
+  "scripts": {
+    "clean": "ionic-app-scripts clean",
+    "build": "ionic-app-scripts build",
+    "lint": "ionic-app-scripts lint",
+    "ionic:build": "ionic-app-scripts build",
+    "ionic:serve": "ionic-app-scripts serve",
+    "test": "ng test"
+  },
+  "dependencies": {
+    "@angular/common": "5.0.0",
+    "@angular/compiler": "5.0.0",
+    "@angular/compiler-cli": "5.0.0",
+    "@angular/core": "5.0.0",
+    "@angular/forms": "5.0.0",
+    "@angular/http": "5.0.0",
+    "@angular/platform-browser": "5.0.0",
+    "@angular/platform-browser-dynamic": "5.0.0",
+    "@auth0/cordova": "^0.3.0",
+    "@ionic-native/core": "4.3.2",
+    "@ionic-native/splash-screen": "4.3.2",
+    "@ionic-native/status-bar": "4.3.2",
+    "@ionic/storage": "2.1.3",
+    "angular2-jwt": "^0.2.3",
+    "auth0-js": "^9.0.2",
+    "cordova-plugin-customurlscheme": "^4.3.0",
+    "cordova-plugin-safariviewcontroller": "^1.5.2",
+    "ionic-angular": "3.9.2",
+    "ionicons": "3.0.0",
+    "rxjs": "5.5.2",
+    "sw-toolbox": "3.6.0",
+    "zone.js": "0.8.18"
+  },
+  "devDependencies": {
+    "@ionic/app-scripts": "3.1.0",
+    "jasmine": "^2.8.0",
+    "karma": "^2.0.0",
+    "typescript": "2.4.2"
+  },
+  "cordova": {
+    "plugins": {
+      "cordova-plugin-safariviewcontroller": {},
+      "cordova-plugin-customurlscheme": {
+        "URL_SCHEME": "com.clueride",
+        "ANDROID_SCHEME": "com.clueride",
+        "ANDROID_HOST": "clueride.auth0.com",
+        "ANDROID_PATHPREFIX": "/cordova/com.clueride/callback"
+      }
     }
+  }
 }

--- a/src/components/components.module.ts
+++ b/src/components/components.module.ts
@@ -2,6 +2,8 @@ import {ModuleWithProviders, NgModule} from '@angular/core';
 import {IonicStorageModule} from "@ionic/storage";
 import {RegistrationPageModule} from "../pages/registration/registration.module";
 import {AuthService} from "../providers/auth/auth.service";
+import {TokenService} from "../providers/token/token.service";
+import {ProfileService} from "../providers/profile/profile.service";
 
 @NgModule({
   imports: [
@@ -14,7 +16,9 @@ export class ComponentsModule {
     return {
       ngModule: ComponentsModule,
       providers: [
-        AuthService
+        AuthService,
+        ProfileService,
+        TokenService
       ]
     }
   }

--- a/src/providers/profile/profile.service.ts
+++ b/src/providers/profile/profile.service.ts
@@ -1,0 +1,29 @@
+/**
+ * Created by jett on 1/8/18.
+ */
+import {Injectable} from "@angular/core";
+import {TokenService} from "../token/token.service";
+
+/**
+ * Knows about the profile portion of the JWT token obtained
+ * from the Token Service.
+ */
+@Injectable()
+export class ProfileService {
+
+  constructor (
+    private tokenService: TokenService
+  ) {
+
+  }
+
+  public getPrincipal(): string {
+    let payload = this.tokenService.getPayload();
+    return payload.email;
+  }
+
+  public getUserImageUrl(): string {
+    return this.tokenService.getPayload().picture;
+  }
+
+}

--- a/src/providers/storage-keys.ts
+++ b/src/providers/storage-keys.ts
@@ -1,0 +1,18 @@
+interface StorageKeySet {
+  profile: string;
+  jwtToken: string;
+  accessToken: string;
+  expiresAt: string;
+}
+
+/**
+ * Keys into the Storage; placed here to avoid repeating across services.
+ * @type {StorageKeySet} object defining the keys shared across services.
+ */
+
+export const STORAGE_KEYS: StorageKeySet = {
+  profile: 'profile',
+  jwtToken: 'id_token',
+  accessToken: 'access_token',
+  expiresAt: 'expires_at'
+}

--- a/src/providers/token/token.service.ts
+++ b/src/providers/token/token.service.ts
@@ -1,22 +1,39 @@
 import { Injectable } from '@angular/core';
 import { Storage } from "@ionic/storage";
+import {JwtHelper} from "angular2-jwt";
+import {STORAGE_KEYS} from "../storage-keys";
 
 /**
- * @deprecated use AuthService instead.
+ * Provides functionality for working with the app's JWT token
+ * that was obtained using the AuthService and stored locally.
  */
 @Injectable()
 export class TokenService {
   TOKEN_KEY: string = "token.key";
   PRINCIPAL_KEY: string = "principal.key";
   private hasAuthToken: boolean = false;
-  // private jwtHelper: JwtHelper;
+  private jwtHelper: JwtHelper;
   payload;
   token: string;
 
   constructor(
     private storage: Storage
   ) {
-    // this.jwtHelper = new JwtHelper();
+    this.jwtHelper = new JwtHelper();
+  }
+
+  getPayload() {
+    return this.decodePayload(localStorage.getItem(STORAGE_KEYS.jwtToken));
+  }
+
+  useJwtHelper() {
+    var token = localStorage.getItem('token');
+
+    console.log(
+      this.jwtHelper.decodeToken(token),
+      this.jwtHelper.getTokenExpirationDate(token),
+      this.jwtHelper.isTokenExpired(token)
+    );
   }
 
   /**
@@ -80,7 +97,7 @@ export class TokenService {
     return this.payload.email;
   }
 
-  private decodePayload(fullToken: string): any {
+  decodePayload(fullToken: string): any {
     if (!fullToken) {
       throw new Error("passed token is not populated");
     }
@@ -88,12 +105,11 @@ export class TokenService {
     if (parts.length !== 3) {
       throw new Error('JWT must have 3 parts');
     }
-    // let decoded = this.jwtHelper.urlBase64Decode(parts[0]);
-    // if (!decoded) {
-    //   throw new Error('Cannot decode the token');
-    // }
-    // return JSON.parse(decoded);
-    return true;
+    let decoded = this.jwtHelper.urlBase64Decode(parts[1]);
+    if (!decoded) {
+      throw new Error('Cannot decode the token');
+    }
+    return JSON.parse(decoded);
   }
 
   public getBadges() {


### PR DESCRIPTION
* Installs the JWT Helper; it comes along with other tools that will be
useful as well.
* Refactors the Keys for Storage into a separate file for sharing across services.
* Adds email to the list of scopes since this is one of the main purposes
of retrieving a user profile and setting up auth.
* Adds Profile Service to break out this cognitive piece.