### PR TITLE
FEC-11 Need separate callbacks for each app

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -83,11 +83,5 @@
     <plugin name="cordova-plugin-splashscreen" spec="~4.0.1" />
     <plugin name="cordova-plugin-ionic-webview" spec="^1.1.11" />
     <plugin name="cordova-plugin-safariviewcontroller" spec="^1.5.2" />
-    <plugin name="cordova-plugin-customurlscheme" spec="^4.3.0">
-        <variable name="URL_SCHEME" value="com.clueride" />
-        <variable name="ANDROID_SCHEME" value="com.clueride" />
-        <variable name="ANDROID_HOST" value="clueride.auth0.com" />
-        <variable name="ANDROID_PATHPREFIX" value="/cordova/com.clueride/callback" />
-    </plugin>
     <plugin name="cordova-plugin-secure-storage" spec="^2.6.8" />
 </widget>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
         "@ionic/storage": "2.1.3",
         "angular2-jwt": "^0.2.3",
         "auth0-js": "^9.0.2",
-        "cordova-plugin-customurlscheme": "^4.3.0",
         "cordova-plugin-safariviewcontroller": "^1.5.2",
         "cordova-plugin-secure-storage": "^2.6.8",
         "ionic-angular": "3.9.2",
@@ -64,13 +63,7 @@
     },
     "cordova": {
         "plugins": {
-            "cordova-plugin-safariviewcontroller": {},
-            "cordova-plugin-customurlscheme": {
-                "URL_SCHEME": "com.clueride",
-                "ANDROID_SCHEME": "com.clueride",
-                "ANDROID_HOST": "clueride.auth0.com",
-                "ANDROID_PATHPREFIX": "/cordova/com.clueride/callback"
-            }
+            "cordova-plugin-safariviewcontroller": {}
         }
     }
 }

--- a/src/providers/auth/auth.service.ts
+++ b/src/providers/auth/auth.service.ts
@@ -16,7 +16,7 @@ auth0Config[REGISTRATION_TYPE.SOCIAL] = {
     // needed for auth0cordova
   clientId: AUTH_CONFIG.clientID.social,
   domain: AUTH_CONFIG.domain.social,
-  packageIdentifier: 'com.clueride'
+  packageIdentifier: 'com.clueride.client'  // Not obvious that this is used to build callback URL.
 };
 
 auth0Config[REGISTRATION_TYPE.PASSWORDLESS] = {
@@ -26,7 +26,7 @@ auth0Config[REGISTRATION_TYPE.PASSWORDLESS] = {
   // needed for auth0cordova
   clientId: AUTH_CONFIG.clientID.passwordless,
   domain: AUTH_CONFIG.domain.passwordless,
-  packageIdentifier: 'com.clueride'
+  packageIdentifier: 'com.clueride.client'  // Not obvious that this is used to build callback URL.
 };
 
 @Injectable()
@@ -97,6 +97,20 @@ export class AuthService {
       return AuthState.EXPIRED;
     }
     return AuthState.UNREGISTERED;
+  }
+
+  /**
+   * The callback URL is built from the "packageIdentifier" that is set in the
+   * Config object. However, we need to set this from the client rather than this
+   * library function.
+   *
+   * NOTE: the scheme needs to also be configured in the 'customurlscheme' plugin and
+   * on the Auth0 website's list of valid callback URLs.
+   * @param scheme - matches the client's unique package identifier.
+   */
+  public setUrlScheme(scheme: string) {
+    auth0Config[REGISTRATION_TYPE.SOCIAL].packageIdentifier = scheme;
+    auth0Config[REGISTRATION_TYPE.PASSWORDLESS].packageIdentifier = scheme;
   }
 
   /**

--- a/src/providers/auth/auth0-variables.ts
+++ b/src/providers/auth/auth0-variables.ts
@@ -7,7 +7,6 @@ interface AuthConfig {
     social: string,
     passwordless: string
   };
-  callbackURL: string;
 }
 
 export const AUTH_CONFIG: AuthConfig = {
@@ -19,5 +18,4 @@ export const AUTH_CONFIG: AuthConfig = {
     social: 'clueride-social.auth0.com',
     passwordless: 'clueride.auth0.com'
   },
-  callbackURL: 'com.clueride://clueride.auth0.com/cordova/com.clueride/callback'
 };


### PR DESCRIPTION
* Removes customurlscheme plugin since it needs to be established per app.
* Allows clients to specify the URL scheme specific to that app.
* Removes unused "callbackURL" property from Auth0 config.