### PR TITLE
Cleanup and Prep

### DIFF
--- a/src/providers/auth/CONTRIBUTING.md
+++ b/src/providers/auth/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Testing
+
+When this code is run from `ionic serve`, the browser that is provided does
+not support making calls out to the 3rd-party Identity Provider to obtain 
+an access token -- which includes much of the code within this component.
+
+To provide this support, you can use `ionic cordova emulate`, but this taxes
+the resources of a machine -- both memory and CPU. It may not perform well.
+
+To provide a less demanding alternative, a configurable account can be used 
+to bypass calls to the 3rd-party Identity Provider.
+
+
+
+Diagram: http://bikehighways.wikidot.com/testing-auth0

--- a/src/providers/auth/README.md
+++ b/src/providers/auth/README.md
@@ -1,0 +1,10 @@
+# Responsibility
+Picking up the Access Token for a given session using 3rd- party
+identity provider.
+
+Two "Types" of registration are supported:
+- "Social" relies on Google or Facebook trust relationships.
+- "Passwordless" confirms possession of a device by sending a code to 
+an email address and asking confirmation.
+
+

--- a/src/providers/auth/auth0-variables.ts
+++ b/src/providers/auth/auth0-variables.ts
@@ -10,6 +10,7 @@ interface AuthConfig {
 }
 
 export const AUTH_CONFIG: AuthConfig = {
+  /* This is publicly shareable. */
   clientID: {
     social: 'ZztcBTDcglTr10lyuLoq8Zy57EW4HXTZ',
     passwordless: 't6RcrSkjxxFfI0JCMsEifO8QJ72YBcDY'


### PR DESCRIPTION
Preparing for move toward Access Token changes that make it easier to
test the front-end without the ability to contact 3rd-party identity providers.