### PR TITLE
LE-91 Need an "Add new Puzzle" button on the Puzzle Edit page

### DIFF
--- a/src/providers/puzzle/puzzle-service.ts
+++ b/src/providers/puzzle/puzzle-service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {BASE_URL, HttpService} from "../http/http.service";
+import {Location} from "../location/location";
 import {LocationService} from "../location/location-service";
 import {Puzzle} from "./puzzle";
 import {Observable, Subject} from "rxjs";
@@ -59,6 +60,26 @@ export class PuzzleService {
 
   public getPuzzlesPerLocationId(locationId: number): Puzzle[] {
     return this.cachedPuzzles[locationId];
+  }
+
+  /** Provides an empty puzzle created by the Server. */
+  public getBlankPuzzleForLocation(location: Location): Observable<Puzzle> {
+    return this.http.post<Puzzle>(
+      BASE_URL + "puzzle/blank",
+      location,
+      {headers: this.httpService.getAuthHeaders()}
+    );
+  }
+
+  /** After making changes, post the updates to the puzzle. */
+  public savePuzzle(
+    puzzle: Puzzle
+  ): Observable<Puzzle> {
+    return this.http.post<Puzzle>(
+      BASE_URL + "puzzle",
+      puzzle,
+      {headers: this.httpService.getAuthHeaders()}
+    );
   }
 
 }


### PR DESCRIPTION
- Builds on the common puzzle service to provide access to two new endpoints:
  - One that provides an empty puzzle associated with the current location.
  - One that allows persisting a filled-out puzzle along with answers.