### PR TITLE
LE-97 Assure registration is complete before kicking off other activity

### DIFF
--- a/src/pages/registration/registration.html
+++ b/src/pages/registration/registration.html
@@ -56,7 +56,7 @@
       </div>
     </div>
 
-    <div id="bdd-mock-register" [hidden]="!auth.runningLocal()">
+    <div id="bdd-mock-register" [hidden]="!platformState.runningLocal()">
       <a (click)="auth.bddLogin()">BDD Mock Register</a>
     </div>
 

--- a/src/pages/registration/registration.ts
+++ b/src/pages/registration/registration.ts
@@ -6,6 +6,7 @@ import {
 } from "../../providers/profile-confirmation-service/profile-confirmation-service";
 import {ConfirmPage} from "../confirm/confirm";
 import {IonicPage, NavController} from 'ionic-angular';
+import {PlatformStateService} from "../../providers/platform-state/platform-state.service";
 import {ProfileConfirmationService} from "../../providers/profile-confirmation-service/profile-confirmation-service";
 import {Title} from "@angular/platform-browser";
 
@@ -25,6 +26,7 @@ export class RegistrationPage implements ConfirmationListener {
 
   constructor(
     public auth: AuthService,
+    public platformState: PlatformStateService,
     public profile: ProfileConfirmationService,
     public navCtrl: NavController,
     public titleService: Title,


### PR DESCRIPTION
- The problem was the registration page was referring to the old
`runningLocal()` method on AuthService instead of the new one on
PlatformStateService. This failure was preventing the Registration page
from being presented -- or picking up a new registration.