### PR TITLE
FEC-37 Server Connection Status

### DIFF
--- a/src/components/heartbeat/heartbeat-state.ts
+++ b/src/components/heartbeat/heartbeat-state.ts
@@ -1,0 +1,6 @@
+
+export enum HeartbeatState {
+  RETRYING,
+  CONNECTED,
+  DISCONNECTED,
+}

--- a/src/components/heartbeat/heartbeat.html
+++ b/src/components/heartbeat/heartbeat.html
@@ -4,7 +4,5 @@
   [class.retrying]='isRetrying()'
   [class.disconnected]='isDisconnected()'
 >
-  <ion-icon name="checkmark-circle" *ngIf="isConnected()"></ion-icon>
-  <ion-icon name="refresh-circle" *ngIf="isRetrying()"></ion-icon>
-  <ion-icon name="close-circle" *ngIf="isDisconnected()"></ion-icon>
+  <ion-icon name="wifi"></ion-icon>
 </span>

--- a/src/components/heartbeat/heartbeat.scss
+++ b/src/components/heartbeat/heartbeat.scss
@@ -2,7 +2,7 @@ heartbeat {
 }
 
 .network-status {
-  font-size: large;
+  font-size: xx-large;
 }
 
 .connected {

--- a/src/components/heartbeat/heartbeat.ts
+++ b/src/components/heartbeat/heartbeat.ts
@@ -1,13 +1,8 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import {Heartbeat, SseEventService} from "../../providers/sse-event/sse-event.service";
+import {HeartbeatState} from "./heartbeat-state";
 import {timer} from "rxjs/observable/timer";
 import {Subject} from "rxjs";
-
-export enum HeartbeatState {
-  RETRYING,
-  CONNECTED,
-  DISCONNECTED,
-}
 
 /* Two seconds longer than the expected heartbeat interval. */
 const TIMEOUT_INTERVAL_IN_SECONDS: number  = 12;
@@ -19,38 +14,64 @@ const TIMEOUT_INTERVAL_IN_SECONDS: number  = 12;
   selector: 'heartbeat',
   templateUrl: 'heartbeat.html'
 })
-export class HeartbeatComponent implements OnInit {
+export class HeartbeatComponent implements OnInit, OnDestroy {
 
-  heartbeatState: HeartbeatState;
+  heartbeatState: HeartbeatState = HeartbeatState.RETRYING;
   private heartbeatSubject: Subject<Heartbeat>;
+
+  /* Subscriptions */
+  connectedSubscription;
+  retryingSubscription;
+  disconnectedSubscription;
 
   constructor(
     private sseService: SseEventService,
   ) {
     console.log('Hello HeartbeatComponent Component');
-    this.heartbeatState = HeartbeatState.RETRYING;
     this.heartbeatSubject = sseService.getHeartbeatSubject();
   }
 
   ngOnInit() {
-    // TODO: Resource leak because this will setup the subscriptions on each entry to this page.
-    this.heartbeatSubject.asObservable()
-      .subscribe(this.connected);
+    this.connectedSubscription =
+      this.heartbeatSubject.asObservable()
+        .map(event => event.state)
+        .subscribe(this.maybeConnected);
 
-    this.heartbeatSubject.asObservable()
-      .startWith(undefined)
-      .switchMap(() => timer(TIMEOUT_INTERVAL_IN_SECONDS * 1000))
-      .subscribe(this.retrying);
+    this.retryingSubscription =
+      this.heartbeatSubject.asObservable()
+        .map(event => event.state)
+        .startWith(undefined)
+        .switchMap(() => timer(TIMEOUT_INTERVAL_IN_SECONDS * 1000))
+        .subscribe(this.retrying);
 
-    this.heartbeatSubject.asObservable()
-      .startWith(undefined)
-      .switchMap(() => timer(TIMEOUT_INTERVAL_IN_SECONDS * 2 * 1000))
-      .subscribe(this.disconnected);
+    this.disconnectedSubscription =
+      this.heartbeatSubject.asObservable()
+        .map(event => event.state)
+        .startWith(undefined)
+        .switchMap(() => timer(TIMEOUT_INTERVAL_IN_SECONDS * 2 * 1000))
+        .subscribe(this.disconnected);
   }
 
-  private connected = () => {
-    console.log("Network Heartbeat: CONNECTED");
-    this.heartbeatState = HeartbeatState.CONNECTED;
+  ngOnDestroy() {
+    this.connectedSubscription.unsubscribe();
+    this.retryingSubscription.unsubscribe();
+    this.disconnectedSubscription.unsubscribe();
+  }
+
+  private maybeConnected = (state: HeartbeatState) => {
+    this.heartbeatState = state;
+    switch (state) {
+      case HeartbeatState.CONNECTED:
+        console.log("Network Heartbeat: CONNECTED");
+        break;
+      case HeartbeatState.DISCONNECTED:
+        console.log("Network (error): DISCONNECTED");
+        break;
+      case HeartbeatState.RETRYING:
+        console.log("Network (how do we get here): RETRYING");
+        break;
+    }
+
   };
 
   private retrying = () => {


### PR DESCRIPTION
Additional improvements:
- Unsubscribes when the component in 'destroyed'.
- Moves the error handling outside of the Observable so that an error
condition doesn't shut down subscriptions -- they propagate as
DISCONNECTED events.
- Moves HeartbeatState out to a separate file to break a circular
dependency.
- Improves the size and type of icon used for Network Status.