### PR TITLE
FEC-44: Profile Confirm Service - Token Service away from workflow path

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ export { AuthState } from  "./src/providers/auth/auth-state";
 export { Badge } from "./src/providers/badge/badge";
 export { BadgeService } from "./src/providers/badge/badge.service";
 export { ComponentsModule } from "./src/components/components.module";
+export { ConfirmationState } from "./src/providers/profile-confirmation-service/confirmation-state";
 export { ConnectionStateComponentModule } from "./src/components/connection-state/connection-state.module";
 export { Course } from "./src/providers/course/course";
 export { CourseService } from "./src/providers/course/course-service";
@@ -26,11 +27,7 @@ export { OutingService } from "./src/providers/outing/outing.service";
 export { PathService } from "./src/providers/path/path.service";
 export { PlatformStateService } from "./src/providers/platform-state/platform-state.service";
 export { ProfileService} from "./src/providers/profile/profile.service";
-export {
-  ProfileConfirmationService,
-  ConfirmationListener,
-  ConfirmationState
-} from "./src/providers/profile-confirmation-service/profile-confirmation-service";
+export { ProfileConfirmationService } from "./src/providers/profile-confirmation-service/profile-confirmation-service";
 export { Puzzle } from "./src/providers/puzzle/puzzle";
 export { PuzzleService } from "./src/providers/puzzle/puzzle-service";
 export { RegStateService } from "./src/providers/reg-state/reg-state.service";

--- a/src/pages/registration/registration.ts
+++ b/src/pages/registration/registration.ts
@@ -1,15 +1,12 @@
 import {AuthService} from "../../providers/auth/auth.service";
 import {Component} from '@angular/core';
-import {
-  ConfirmationListener,
-  ConfirmationState
-} from "../../providers/profile-confirmation-service/profile-confirmation-service";
 import {ConfirmPage} from "../confirm/confirm";
 import {IonicPage, NavController} from 'ionic-angular';
 import {PlatformStateService} from "../../providers/platform-state/platform-state.service";
 import {ProfileConfirmationService} from "../../providers/profile-confirmation-service/profile-confirmation-service";
 // tslint:disable-next-line
 import {Title} from "@angular/platform-browser";
+import {Subscription} from "rxjs";
 
 /**
  * Generated class for the RegistrationPage page.
@@ -23,7 +20,8 @@ import {Title} from "@angular/platform-browser";
   selector: 'page-registration',
   templateUrl: 'registration.html',
 })
-export class RegistrationPage implements ConfirmationListener {
+export class RegistrationPage {
+  private confirmationStateSubscription: Subscription;
 
   constructor(
     public auth: AuthService,
@@ -32,21 +30,28 @@ export class RegistrationPage implements ConfirmationListener {
     public navCtrl: NavController,
     public titleService: Title,
   ) {
-    /** Add ourselves to the list of profile listeners. */
-    profileConfirmationService.listeners.push(this);
   }
 
   ionViewDidEnter() {
     this.titleService.setTitle("Registration");
+
+    /** Add ourselves to the list of profile listeners. */
+    this.confirmationStateSubscription = this.profileConfirmationService.confirmationState$.subscribe(
+      (confirmationState) =>    {
+        if (confirmationState.authenticated && !confirmationState.confirmed) {
+          console.log("Have Authentication, but email is not yet confirmed");
+          this.navCtrl.push(ConfirmPage)
+            .then()
+            .catch();
+        } else {
+          console.log("Confirmation State: " + JSON.stringify(confirmationState));
+        }
+      }
+    );
   }
 
-  // TODO: this appears to be how we get to the Confirmation page.
-  public canWeSwitch(confirmationState: ConfirmationState) {
-    if (confirmationState.authenticated && !confirmationState.confirmed) {
-      this.navCtrl.push(ConfirmPage)
-        .then()
-        .catch();
-    }
+  ionViewWillLeave() {
+    this.confirmationStateSubscription.unsubscribe();
   }
 
 }

--- a/src/providers/profile-confirmation-service/confirmation-state.ts
+++ b/src/providers/profile-confirmation-service/confirmation-state.ts
@@ -1,0 +1,13 @@
+/**
+ * This is the event which notifies observers of changes to the confirmation state
+ * as well as authentication.
+ *
+ * After authentication against a particular service, the user is given a chance to
+ * decide whether to proceed with device registration using the email address given
+ * in the profile, or to start over and try with another profile. This tells us
+ * whether the user agrees to use the current email or not.
+ */
+export class ConfirmationState {
+  authenticated: boolean = false;
+  confirmed: boolean = false;
+}

--- a/src/providers/profile-confirmation-service/profile-confirmation-service.ts
+++ b/src/providers/profile-confirmation-service/profile-confirmation-service.ts
@@ -1,38 +1,46 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import {ConfirmationState} from "./confirmation-state";
+// tslint:disable-next-line
+import {Subject, Observable} from "rxjs";
 
 /**
  * Service for confirming the user agrees to use a certain email address.
  */
 @Injectable()
 export class ProfileConfirmationService {
+  public confirmationSubject: Subject<ConfirmationState>;
+  public confirmationState$: Observable<ConfirmationState>;
   confirmed: boolean = false;
-  public listeners: ConfirmationListener[] = [];
 
   constructor(
     public http: HttpClient
   ) {
     console.log('Hello ProfileConfirmationServiceProvider Provider');
+    this.confirmationSubject = new Subject<ConfirmationState>();
+    this.confirmationState$ = this.confirmationSubject.asObservable();
   }
 
   public confirm(confirmationState: ConfirmationState) {
     this.confirmed = confirmationState.confirmed;
-    for (let listener of this.listeners) {
-      listener.canWeSwitch(confirmationState);
-    }
+    this.confirmationSubject.next(confirmationState);
   }
 
   public isConfirmed(): boolean {
     return this.confirmed;
   }
 
+  /**
+   * Trigger the event indicating we've authenticated, but not yet confirmed.
+   */
+  receiveAuthorization() {
+    this.confirmationSubject.next(
+      {
+        confirmed: false,
+        authenticated: true,
+      }
+    );
+  }
+
 }
 
-export interface ConfirmationListener {
-  canWeSwitch: (event: any) => any
-}
-
-export class ConfirmationState {
-  authenticated: boolean = false;
-  confirmed: boolean = false;
-}

--- a/src/providers/token/token.service.ts
+++ b/src/providers/token/token.service.ts
@@ -15,7 +15,6 @@ export class TokenService {
   token: string;
 
   constructor(
-    private profileConfirmationService: ProfileConfirmationService
   ) {
     this.payload = JSON.parse(
       window.localStorage.getItem(STORAGE_KEYS.profile)
@@ -84,29 +83,11 @@ export class TokenService {
     );
 
     this.setExpiresAtFromPayload(this.payload.exp);
-
-    // TODO: This indirectly affects the navigation to the Confirmation Page.
-    this.profileConfirmationService.confirm(
-      {
-        authenticated: true,
-        confirmed: false
-      }
-    );
-
     this.setStorageVariable(STORAGE_KEYS.jwtToken, token);
   }
 
   public setAccessToken(token) {
     this.setStorageVariable(STORAGE_KEYS.accessToken, token);
-
-    // TODO: This indirectly affects the navigation to the Confirmation Page.
-    this.profileConfirmationService.confirm(
-      {
-        authenticated: true,
-        confirmed: false
-      }
-    );
-
   }
 
   public getRegistrationType(): string {


### PR DESCRIPTION
- Takes Token Service out of the path for notification of profile confirmation.
- Adds options to `authorize` call to bring back the Renewal Token.
- Refactors the Profile Confirmation Service to use RxJS.