### PR TITLE
PLAY-72 For current path, show start/end icons with red and green as …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -481,9 +481,9 @@
       }
     },
     "@types/jasmine": {
-      "version": "2.8.16",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.16.tgz",
-      "integrity": "sha1-pssksRSdZSk71haSNQABSDjhTn0=",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.9.tgz",
+      "integrity": "sha512-8dPZwjosElZOGGYw1nwTvOEMof4gjwAWNFS93nBI091BoEfd5drnHOLRMiRF/LOPuMTn5LgEdv0bTUO8QFVuHQ==",
       "dev": true
     },
     "@types/localforage": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@angular/cli": "^1.6.5",
     "@ionic-native-mocks/secure-storage": "^2.0.6",
     "@ionic/app-scripts": "3.1.0",
-    "@types/jasmine": "^2.8.4",
+    "@types/jasmine": "^2.8.9",
     "@types/node": "^9.3.0",
     "ionic-mocks": "^1.2.1",
     "jasmine": "^2.8.0",
@@ -58,7 +58,7 @@
     "karma-jasmine": "^1.1.1",
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-junit-reporter": "^1.2.0",
-    "typescript": "2.4.2"
+    "typescript": "^2.4.2"
   },
   "cordova": {
     "plugins": {

--- a/src/providers/attraction/attraction-service.spec.ts
+++ b/src/providers/attraction/attraction-service.spec.ts
@@ -1,0 +1,55 @@
+import {TestBed} from "@angular/core/testing";
+import {AttractionService} from "./attraction-service";
+import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {HttpService} from "../http/http.service";
+import {TokenService} from "../token/token.service";
+import {OutingService} from "../outing/outing.service";
+
+let toTest: AttractionService;
+
+describe("attraction-service", () => {
+
+  beforeEach (() => {
+    TestBed.configureTestingModule(
+      {
+        providers: [
+          AttractionService,
+          HttpService,
+          OutingService,
+          TokenService,
+        ],
+        imports:[
+          HttpClientTestingModule,
+        ],
+      }
+    ).compileComponents()
+      .then(
+        () => {
+          console.log("Compile successful");
+        }
+      );
+
+    // We don't see the compilation errors if we catch them.
+      // .catch(reason => {
+      //   console.log("Unable to Compile")
+      // });
+
+    toTest = TestBed.get(AttractionService);
+  });
+
+  it("should exist", () => {
+    expect(toTest).toBeTruthy();
+  });
+
+  describe("getVisibleAttractions", () => {
+
+  });
+
+  describe("classifyVisibleAttractions", () => {
+
+    it("should exist", () => {
+      expect(toTest.classifyVisibleAttractions).toBeTruthy();
+    });
+  });
+
+});

--- a/src/providers/attraction/attraction.ts
+++ b/src/providers/attraction/attraction.ts
@@ -24,4 +24,6 @@ export class Attraction {
   featuredImage: Image;
   establishmentId?: number;
   readinessLevel: string;
+  isLast?: boolean;
+  isCurrent?: boolean;
 }

--- a/src/providers/auth/auth.services.spec.ts
+++ b/src/providers/auth/auth.services.spec.ts
@@ -50,64 +50,6 @@ describe("Services: AuthService", () => {
     expect(toTest).toBeDefined();
   });
 
-  describe("checkRegistrationRequired", () => {
-
-    it("should resolve true when unregistered",
-      inject(
-        [HttpTestingController],
-        (httpMock: HttpTestingController) => {
-
-          /* make call */
-          let actualPromise = toTest.checkRegistrationRequired();
-
-          /* verify results */
-          actualPromise.then(
-            (actual) => {
-              expect(actual).toBeTruthy();
-            }
-          );
-        }
-      )
-    );
-
-    it("should resolve false when registered",
-      inject(
-        [HttpTestingController],
-        (httpMock: HttpTestingController) => {
-
-          /* setup data */
-          tokenService.bddRegister();
-
-          /* make call */
-          let actualPromise = toTest.checkRegistrationRequired();
-
-          /* Set HTTP expectations. */
-          const requestExpectation = httpMock.expectOne("https://player.clueride.com/rest/access/state");
-          expect(requestExpectation.request.method).toEqual('GET');
-
-          /* Mock the HTTP response. */
-          requestExpectation.flush(
-            "true",
-            {
-              status: 200,
-              statusText: 'OK'
-            }
-          );
-
-          /* verify results */
-          actualPromise.then(
-            (actual) => {
-              expect(actual).toBeFalsy();
-              // done();
-            }
-          );
-
-        }
-      )
-    );
-
-  });
-
   describe("getRegistrationState", () => {
 
     it("should return UNREGISTERED when tokens are empty",

--- a/src/providers/geo-loc/geo-loc.spec.ts
+++ b/src/providers/geo-loc/geo-loc.spec.ts
@@ -22,8 +22,7 @@ describe("Geo-Location", () => {
     deviceGeoLocService = new DeviceGeoLocService();
 
     toTest = new GeoLocService(
-      deviceGeoLocService,
-      restangularService
+      deviceGeoLocService
     );
 
   });


### PR DESCRIPTION
…the "GO" and "STOP"

- Supports the Play icons by expanding the Attraction functionality to
carry a flag for the current and next (last) attractions being shown.
- Cleans up and prepares for `spec` files.