### PR TITLE
FEC-50 Record correct Expiration Time for Access Token

### DIFF
--- a/src/components/loader/loader.ts
+++ b/src/components/loader/loader.ts
@@ -1,3 +1,4 @@
+// tslint:disable-next-line
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {LoadingController} from "ionic-angular";
 

--- a/src/providers/member/member.service.ts
+++ b/src/providers/member/member.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {BASE_URL, HttpService} from "../http/http.service";
 import {Member} from "../profile/member";
+// tslint:disable-next-line
 import {Observable} from "rxjs";
 
 /**

--- a/src/providers/team/team-service.ts
+++ b/src/providers/team/team-service.ts
@@ -2,10 +2,17 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {BASE_URL, HttpService} from "../http/http.service";
 import {Team} from "./team";
+// tslint:disable-next-line
 import {Observable} from "rxjs";
 
-/** Caching service for the Team associated with this Session.
+/**
+ * Handles calls to Team endpoints.
+ *
+ * The caching service handles the Team associated with a Session.
  * This data is static for the duration of the session.
+ *
+ * This also supports Invitations and creating the teams to be
+ * invited.
  */
 @Injectable()
 export class TeamService {

--- a/src/providers/token/token.service.ts
+++ b/src/providers/token/token.service.ts
@@ -49,11 +49,19 @@ export class TokenService {
     return JSON.parse(decoded);
   }
 
-  setExpiresAtFromPayload(payloadExpAttribute: string): void {
-    let expiresAtMilliseconds = JSON.parse(payloadExpAttribute) * 1000;
-    window.localStorage.setItem(
+  /**
+   * When given 'expires_in' instead of 'expires_at', we calculate the expiration time based on adding the
+   * given value to the current time.
+   *
+   * Grace period should avoid the delay in milliseconds between receiving the value and when we attempt to renew.
+   *
+   * @param expiration_period_in_seconds
+   */
+  setExpiresAtFromPeriod(expiration_period_in_seconds: number): void {
+    const expiresAt = Date.now() + (1000 * expiration_period_in_seconds);
+    this.setStorageVariable(
       STORAGE_KEYS.expiresAt,
-      JSON.stringify(expiresAtMilliseconds)
+      JSON.stringify(expiresAt)
     );
   }
 
@@ -104,7 +112,6 @@ export class TokenService {
       this.payload
     );
 
-    this.setExpiresAtFromPayload(this.payload.exp);
     this.setStorageVariable(STORAGE_KEYS.jwtToken, jwtToken);
   }
 
@@ -146,6 +153,10 @@ export class TokenService {
     /* Record the token we'll use for testing. */
     this.setAccessToken(bddMockToken.accessToken);
     this.setRegistrationType(REGISTRATION_TYPE.SOCIAL);
+  }
+
+  hasRefreshToken() {
+    return !!this.getRefreshToken();
   }
 
 }


### PR DESCRIPTION
- Replaces token service method that sets expiration from the JWT result
with one that sets expiration based on access token result.

Some cleanup of ts-lint problems too.